### PR TITLE
Update ComputerCraft.cfg

### DIFF
--- a/config/ComputerCraft.cfg
+++ b/config/ComputerCraft.cfg
@@ -28,7 +28,7 @@ general {
     B:http_enable=true
 
     # A semicolon limited list of wildcards for domains that can be accessed through the "http" API on Computers. Set this to "*" to access to the entire internet. Example: "*.pastebin.com;*.github.com;*.computercraft.info" will restrict access to just those 3 domains.
-    S:http_whitelist="*"
+    S:http_whitelist=*.pastebin.com;*.github.com;*.computercraft.info;*
 
     # The range of Wireless Modems at maximum altitude in clear weather, in meters
     I:modem_highAltitudeRange=384


### PR DESCRIPTION
The current whitelist prevents any use of HTTP within computercraft.  While I can't guarantee the wildcard at the end will allow other sites, this at least will allow the two primary sources (github and pastebin) to be used until the wildcard works as intended.
