### PR TITLE
Update microblocks.cfg

### DIFF
--- a/config/microblocks.cfg
+++ b/config/microblocks.cfg
@@ -54,6 +54,7 @@
 
 "minecraft:crafting_table"
 
+"OpenBlocks:canvas"
 
 
 


### PR DESCRIPTION
I added Canvas because the white is so beautiful to use and in tight spots it fits well.

Note: I tested it on my own instance.
