### PR TITLE
Removing the Waslie Core config, as it's no longer needed

### DIFF
--- a/config/WaslieCore.cfg
+++ b/config/WaslieCore.cfg
@@ -1,2 +1,0 @@
-# Configuration file
-


### PR DESCRIPTION
Remove the Waslie Core config, as the mod is no longer there.
