### PR TITLE
Update Vanilla.json

### DIFF
--- a/config/cofh/world/Vanilla.json
+++ b/config/cofh/world/Vanilla.json
@@ -165,7 +165,7 @@
         "maxHeight": 128,
         "retrogen": "true",
         "biomeRestriction": "none",
-        "biomes": []
+        "biomes": [],
         "dimensionRestriction": "blacklist",
         "dimensions": [
             -1,


### PR DESCRIPTION
There was a missing comma in the setup for clay.  Apparently, this means the cofh ore gen skips the entire file for sanity's sake...
