### PR TITLE
Cosmetic changes, and minor training wheels

### DIFF
--- a/config/OpenComputers.cfg
+++ b/config/OpenComputers.cfg
@@ -37,7 +37,7 @@ opencomputers {
     # This controls how often holograms 'flicker'. This is the chance that it
     # flickers for *each frame*, meaning if you're running at high FPS you
     # may want to lower this a bit, to avoid it flickering too much.
-    hologramFlickerFrequency=0.025
+    hologramFlickerFrequency=0
 
     # This controls the maximum scales of hologram projectors, by tier.
     # The size at scale 1 is 3x2x3 blocks, at scale 3 the hologram will
@@ -55,8 +55,8 @@ opencomputers {
     # The scale is in "hologram sizes", i.e. scale 1 allows offsetting a
     # hologram once by its own size.
     hologramMaxTranslation=[
-      0.25,
-      0.5
+      2,
+      2
     ]
 
     # The maximum render distance of a hologram projected by a highest tier
@@ -564,7 +564,7 @@ opencomputers {
     # applies *per extracted item*. For example, if an item was crafted from
     # three other items and gets disassembled, each of those three items has
     # this chance of breaking in the process.
-    disassemblerBreakChance=0.05
+    disassemblerBreakChance=0.00
 
     # Controls how noisy results from the Geolyzer are. This is the maximum
     # deviation from the original value at the maximum vertical distance
@@ -572,7 +572,7 @@ opencomputers {
     # to the Geolyzer. So yes, on the same height, the returned value are of
     # equal 'quality', regardless of the real distance. This is a performance
     # trade-off.
-    geolyzerNoise=4
+    geolyzerNoise=0
 
     # The range, in blocks, in which the Geolyzer can scan blocks. Note that
     # it uses the maximum-distance, not the euclidean one, i.e. it can scan


### PR DESCRIPTION
Holograms, just like bow ties, are cool.  flickering holograms, are not so much... the flickering is also quite different on faster hardware.  Proposing change to make using holograms more attractive, inviting players to perhaps want something to make for opencomputers.

Hologram translation is another cosmetic thing, after playing with it, it looks quite fine, and allows you to stack holograms for more interesting effects.  (can translate their fields next to each other, hide hologram projectors in ceilings, walls)

Geolyzer - there's no programmatic way to reduce or eliminate the noise, it is random and evenly distributed - (well, multiple geolyzers, placed in lots of different locations, networked together... sure maybe)

Dissembler training wheels - eliminate breakage, the mod is already pretty grindy, at least lets not punish players for doing it wrong. (makes it easier to dismantle an improperly configured robot/drone/micro-controller... etc)
