### PR TITLE
Add scripts for NEI culling

### DIFF
--- a/config/INpureProjects/custom_nei_filters/Bootstrap.js
+++ b/config/INpureProjects/custom_nei_filters/Bootstrap.js
@@ -8,3 +8,5 @@ var Bibliocraft_enabled = true;
 var AE2_enabled = true;
 var Tcon_enabled = true;
 var MFR_enabled = true;
+var OpenBlocks_enabled = true;
+var ExtraCells_enabled = true;

--- a/config/INpureProjects/custom_nei_filters/ExtraCells.js
+++ b/config/INpureProjects/custom_nei_filters/ExtraCells.js
@@ -1,0 +1,3 @@
+if (FML.isModLoaded("extracells") && ExtraCells_enabled){
+    NEI.override("extracells:pattern.fluid", [0]);
+}

--- a/config/INpureProjects/custom_nei_filters/OpenBlocks.js
+++ b/config/INpureProjects/custom_nei_filters/OpenBlocks.js
@@ -1,0 +1,3 @@
+if (FML.isModLoaded("OpenBlocks") && OpenBlocks_enabled){
+    NEI.override("OpenBlocks:tank", [0]);
+}

--- a/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
+++ b/config/INpureProjects/custom_nei_filters/custom_nei_filters.cfg
@@ -4,10 +4,12 @@ scripting {
     S:AE2_enabled=true
     S:Bibliocraft_enabled=true
     S:BuildCraft_enabled=true
+    S:ExtraCells_enabled=true
     S:ExtraUtilities_enabled=true
     S:ForgeMicroblock_enabled=true
     S:MFR_enabled=true
     S:Mekanism_enabled=true
+    S:OpenBlocks_enabled=true
     S:Tcon_enabled=true
     S:ThermalExpansion_enabled=true
     S:vanilla_enabled=true

--- a/config/INpureProjects/custom_nei_filters/nei_filters.toc
+++ b/config/INpureProjects/custom_nei_filters/nei_filters.toc
@@ -13,3 +13,5 @@ Bibliocraft.js
 AppliedEnergistics2.js
 Tcon.js
 MFR.js
+OpenBlocks.js
+ExtraCells.js


### PR DESCRIPTION
I made these for Flux Galaxy, but figured you guys could use them too. These scripts hide all extra OpenBlocks Tanks and ExtraCells ME Fluid Patterns for various fluids (which all take up quite a few pages in NEI). The regular (empty) tank and fluid pattern still show up in NEI though.
