### PR TITLE
Update Sanguimancy.cfg -resolve potion ID conflict

### DIFF
--- a/config/Sanguimancy.cfg
+++ b/config/Sanguimancy.cfg
@@ -25,7 +25,7 @@ balancing {
 features {
     I:addHeartPotionID=100
     B:messageWhenCorruptionEffect=true
-    I:removeHeartPotionID=101
+    I:removeHeartPotionID=117
     I:soulNetworkDimensionID=42
 }
 


### PR DESCRIPTION
Resolve potion ID conflict with bound armor with speed sigil embedded.
117 is the next free potion id after looking at NEI potion data dump.
