### PR TITLE
Switch Building Guide Redstone to Inverted

### DIFF
--- a/config/OpenBlocks.cfg
+++ b/config/OpenBlocks.cfg
@@ -186,7 +186,7 @@ graves {
 
 guide {
     # How builder guide should react to redstone. 0 - not sensitive, 1 - powered == on, -1 - inverted
-    I:redstoneSensitivity=1
+    I:redstoneSensitivity=-1
 
     # Square of guide maximum render distance
     D:renderDistanceSq=65536.0


### PR DESCRIPTION
It was inverted in TPPI1; it really sucks to be normal redstone control.
