### PR TITLE
Add Deep Dark Portal to Mekanism Blacklist

### DIFF
--- a/config/mekanism/BoxBlacklist.txt
+++ b/config/mekanism/BoxBlacklist.txt
@@ -38,6 +38,9 @@ superMassiveTech:invisibleLight:0
 # Applied Energistics 2
 appliedenergistics2:tile.BlockDrive:0
 
+#Extra Utilities
+ExtraUtilities:dark_portal:*
+
 # Carpenters Blocks
 CarpentersBlocks:blockCarpentersSafe:*
 CarpentersBlocks:blockCarpentersDoor:*


### PR DESCRIPTION
Deep Dark portal can be placed, entered, and then copied with a cardboard box. Allowing infinite portals and dimension resets. Needs nerf.
